### PR TITLE
Add flag to tell mods the game

### DIFF
--- a/big_funking_dig/mods/default/init.lua
+++ b/big_funking_dig/mods/default/init.lua
@@ -7,6 +7,7 @@ WATER_ALPHA = 160
 WATER_VISC = 1
 LAVA_VISC = 7
 LIGHT_MAX = 14
+BIG_FUNKING_DIG = 1
 
 -- Definitions made by this mod that other mods can use too
 default = {}


### PR DESCRIPTION
This allows mods to see what game it is reliably, without doing stupid things with minetest.registered_items.
