### PR TITLE
Fixed code for arrows

### DIFF
--- a/mods/throwing/arrow.lua
+++ b/mods/throwing/arrow.lua
@@ -84,13 +84,13 @@ minetest.register_entity("throwing:arrow_entity", THROWING_ARROW_ENTITY)
 minetest.register_craft({
 	output = "throwing:arrow 16",
 	recipe = {
-		{"default:stick", "default:stick", "default:steel_ingot"},
+		{"tools:stick", "tools:stick", "tools:steel_ingot"},
 	}
 })
 
 minetest.register_craft({
 	output = "throwing:arrow 16",
 	recipe = {
-		{"default:steel_ingot", "default:stick", "default:stick"},
+		{"tools:steel_ingot", "tools:stick", "tools:stick"},
 	}
 })

--- a/mods/throwing/fire_arrow.lua
+++ b/mods/throwing/fire_arrow.lua
@@ -50,14 +50,14 @@ THROWING_ARROW_ENTITY.on_step = function(self, dtime)
 			if obj:get_luaentity() ~= nil then
 				if obj:get_luaentity().name ~= "throwing:arrow_fire_entity" and obj:get_luaentity().name ~= "__builtin:item" then
 					if self.node ~= "" then
-						minetest.env:set_node(self.lastpos, {name="default:torch"})
+						minetest.env:set_node(self.lastpos, {name="deco:torch"})
 						minetest.sound_play("default_place_node", {pos = self.lastpos})
 					end
 					self.object:remove()
 				end
 			else
 				if self.node ~= "" then
-					minetest.env:set_node(self.lastpos, {name="default:torch"})
+					minetest.env:set_node(self.lastpos, {name="deco:torch"})
 					minetest.sound_play("default_place_node", {pos = self.lastpos})
 				end
 				self.object:remove()
@@ -68,7 +68,7 @@ THROWING_ARROW_ENTITY.on_step = function(self, dtime)
 	if self.lastpos.x~=nil then
 		if node.name ~= "air" then
 			if self.node ~= "" then
-				minetest.env:set_node(self.lastpos, {name="default:torch"})
+				minetest.env:set_node(self.lastpos, {name="deco:torch"})
 				minetest.sound_play("default_place_node", {pos = self.lastpos})
 			end
 			self.object:remove()


### PR DESCRIPTION
Fixed the crafting recipes for "throwing:arrow" so that it uses the new naming rather than the "default" naming.